### PR TITLE
fix: crash on script unload

### DIFF
--- a/src/IpTracker_SC.cpp
+++ b/src/IpTracker_SC.cpp
@@ -8,10 +8,10 @@
 #include "ScriptMgr.h"
 #include "StringFormat.h"
 
-class IpTracker : public AccountScript, public WorldScript
+class IpTracker : public AccountScript
 {
 public:
-    IpTracker() : AccountScript("IpTracker"), WorldScript("IpTracker") { }
+    IpTracker() : AccountScript("IpTracker") { }
 
     void OnLastIpUpdate(uint32 accountId, std::string ip) override
     {
@@ -23,6 +23,12 @@ public:
         std::string query = Acore::StringFormatFmt("INSERT INTO `account_ip` (`account`, `ip`, `first_time`, `last_time`) VALUES ({}, '{}', NOW(), NOW()) ON DUPLICATE KEY UPDATE `last_time` = NOW()", accountId, ip);
         LoginDatabase.Execute(query.c_str());
     }
+};
+
+class IpTrackerWorldScript : public WorldScript
+{
+public:
+    IpTrackerWorldScript() : WorldScript("IpTracker") { }
 
     void OnStartup() override
     {
@@ -42,4 +48,5 @@ public:
 void AddSC_IpTracker()
 {
     new IpTracker();
+    new IpTrackerWorldScript();
 }


### PR DESCRIPTION
Fix a crash happening when unloading the scripts.
The previous implementation was assigning the same pointer to both scripts, and when we tried to unload them, we deleted first the account script and then, when we tried to delete the WorldScript, it caused a segmentation fault by dereferencing a null pointer, as we previously deleted the pointer of the script on AccountScript.
This is already tested and it is confirmed it fixes the crash :)